### PR TITLE
Change DiagnosticId from Exceptional.ThrowSiteAnalyzer to ExceptionalThrowSiteAnalyzer

### DIFF
--- a/src/ExceptionalAnalyzers/Analyzers/ThrowSiteAnalyzer.cs
+++ b/src/ExceptionalAnalyzers/Analyzers/ThrowSiteAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Exceptional.Analyzers.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class ThrowSiteAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "Exceptional.ThrowSiteAnalyzer";
+        public const string DiagnosticId = "ExceptionalThrowSiteAnalyzer";
 
         private static readonly LocalizableString Title =
             new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));


### PR DESCRIPTION
I don't know if any one is watching this repo, or if anyone cares, but fwiw:

I tried running the analyzer in VS2019 and got failures from it because something doesn't like the '.' in the DiagnosticId of ThrowSiteAnalyzer - I removed that and then it started running.